### PR TITLE
fix: add unstable to the list of banned tags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn tags_after_timestamp(
         repository, image
     );
 
-    let banned_tags = vec!["latest", "dev", "rc", "test"];
+    let banned_tags = vec!["latest", "dev", "rc", "test", "unstable"];
 
     let mut tags: Vec<String> = Vec::new();
 


### PR DESCRIPTION
Both fmriprep and aslprep create images with this tag that we don't want to bother pulling to Oscar